### PR TITLE
docs: adicionar issue template para desafios da alpar academy

### DIFF
--- a/.github/ISSUE_TEMPLATE/desafio-da-alpar-academy.md
+++ b/.github/ISSUE_TEMPLATE/desafio-da-alpar-academy.md
@@ -1,0 +1,11 @@
+---
+name: Desafio da Alpar Academy
+about: Adiciona descrição do desafio diário da Alpar Academy ao GitHub Issues.
+title: "[CONTEUDO] - Desafio [x]"
+labels: ''
+assignees: GEdO23
+
+---
+
+# <conteudo>
+## Desafio <número>


### PR DESCRIPTION
Adicionar um Issue Template que descreve os desafios diários lançados pela Alpar Academy em sua plataforma.

Esta adição se faz necessária para uma melhor organização dos desafios de cada dia, e seguir as Community Standards do GitHub.

